### PR TITLE
Integrate intrinsic rewards and restore logs

### DIFF
--- a/Content/Python/Source/Runner.py
+++ b/Content/Python/Source/Runner.py
@@ -521,6 +521,7 @@ class RLRunner:
             batch_obs_update,
             batch_act_update,
             batch_returns_update,
+            batch_rew_update,
             batch_logp_update,
             batch_val_update,
             batch_base_update,


### PR DESCRIPTION
## Summary
- incorporate intrinsic rewards into episode returns in `MAPOCAAgent.update`
- log extrinsic reward statistics and value predictions again
- pass padded reward sequences through `Runner` to agent
------
https://chatgpt.com/codex/tasks/task_e_686878af0b648323942b3e12869ba412