### PR TITLE
Add needs_action mask for selective step finalization

### DIFF
--- a/Source/Mecanum_Robot_RL/Private/RLRunner.cpp
+++ b/Source/Mecanum_Robot_RL/Private/RLRunner.cpp
@@ -211,6 +211,8 @@ void ARLRunner::DecideActions()
     EnvDones.SetNum(Environments.Num());
     TArray<float> EnvTruncs;
     EnvTruncs.SetNum(Environments.Num());
+    TArray<float> NeedsAction;
+    NeedsAction.SetNum(Environments.Num());
 
     for (int32 i = 0; i < Environments.Num(); i++)
     {
@@ -224,9 +226,10 @@ void ARLRunner::DecideActions()
         bool bCurrentTrunc = Environments[i]->Trunc();
         EnvDones[i] = bCurrentDone ? 1.f : 0.f;
         EnvTruncs[i] = bCurrentTrunc ? 1.f : 0.f;
+        NeedsAction[i] = (Pending[i].RepeatCounter == 0) ? 1.f : 0.f;
     }
 
-    TArray<FAction> newActions = GetActionsFromPython(EnvStates, EnvDones, EnvTruncs);
+    TArray<FAction> newActions = GetActionsFromPython(EnvStates, EnvDones, EnvTruncs, NeedsAction);
 
     for (int32 i = 0; i < Environments.Num(); i++)
     {
@@ -400,7 +403,8 @@ FState ARLRunner::GetEnvState(ABaseEnvironment* Env)
 TArray<FAction> ARLRunner::GetActionsFromPython(
     const TArray<FState>& EnvStates,
     const TArray<float>& EnvDones,
-    const TArray<float>& EnvTruncs
+    const TArray<float>& EnvTruncs,
+    const TArray<float>& NeedsAction
 )
 {
     if (!AgentComm)
@@ -408,7 +412,7 @@ TArray<FAction> ARLRunner::GetActionsFromPython(
         UE_LOG(LogTemp, Warning, TEXT("AgentComm is null in GetActionsFromPython, sampling random actions."));
         return SampleAllEnvActions();
     }
-    return AgentComm->GetActions(EnvStates, EnvDones, EnvTruncs, CurrentAgents);
+    return AgentComm->GetActions(EnvStates, EnvDones, EnvTruncs, NeedsAction, CurrentAgents);
 }
 
 TArray<FAction> ARLRunner::SampleAllEnvActions()

--- a/Source/Mecanum_Robot_RL/Public/RLRunner.h
+++ b/Source/Mecanum_Robot_RL/Public/RLRunner.h
@@ -12,7 +12,7 @@
 #include "RLRunner.generated.h"
 
 /**
- * Holds ìpendingî data for each environment with action-repeat:
+ * Holds ‚Äúpending‚Äù data for each environment with action-repeat:
  *   - The last state from the beginning of the repeated-block
  *   - The chosen action
  *   - Accumulated reward
@@ -145,6 +145,6 @@ private:
     void MaybeTrainUpdate();
 
     /** Gather actions from Python or fallback random. */
-    TArray<FAction> GetActionsFromPython(const TArray<FState>& EnvStates, const TArray<float>& EnvDones, const TArray<float>& EnvTruncs);
+    TArray<FAction> GetActionsFromPython(const TArray<FState>& EnvStates, const TArray<float>& EnvDones, const TArray<float>& EnvTruncs, const TArray<float>& NeedsAction);
     TArray<FAction> SampleAllEnvActions();
 };

--- a/Source/Mecanum_Robot_RL/Public/SharedMemoryAgentCommunicator.h
+++ b/Source/Mecanum_Robot_RL/Public/SharedMemoryAgentCommunicator.h
@@ -44,7 +44,7 @@ public:
      *   - Reads actions back from shared memory
      */
     UFUNCTION(BlueprintCallable, Category = "SharedMemory")
-    TArray<FAction> GetActions(TArray<FState> States, TArray<float> Dones, TArray<float> Truncs, int NumAgents);
+    TArray<FAction> GetActions(TArray<FState> States, TArray<float> Dones, TArray<float> Truncs, TArray<float> NeedsAction, int NumAgents);
 
     /**
      * Send a batch of experiences for training updates:


### PR DESCRIPTION
## Summary
- extend `SharedMemoryAgentCommunicator::GetActions` with a `needs_action` mask
- store mask in shared memory and increase its allocation size
- read the mask in Python `Environment.get_states`
- finalize steps only for environments needing an action in Python `Runner`
- pass mask from `RLRunner` when requesting actions