### PR TITLE
Fix final-step bootstrapping in GAE

### DIFF
--- a/Content/Python/Agents/MAPOCAAgent.py
+++ b/Content/Python/Agents/MAPOCAAgent.py
@@ -575,7 +575,7 @@ class MAPOCAAgent(Agent):
         for t in reversed(range(T)):
             # Get masks for the current and next steps. Next step is invalid if current is the last.
             valid_mask_step = mask_bt1[:, t]
-            valid_mask_next_step = mask_bt1[:, t + 1] if t < T - 1 else torch.zeros_like(valid_mask_step)
+            valid_mask_next_step = mask_bt1[:, t + 1] if t < T - 1 else torch.ones_like(valid_mask_step)
 
             # Bootstrapping is valid if the current step is not a 'done' terminal state
             # and the next step is a valid, non-padded part of the sequence.

--- a/Content/Python/Source/tests/test_returns.py
+++ b/Content/Python/Source/tests/test_returns.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import torch
+
+# Add path to import MAPOCAAgent
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from Agents.MAPOCAAgent import MAPOCAAgent
+
+
+def test_bootstrapped_returns_uses_bootstrap_value():
+    agent = MAPOCAAgent.__new__(MAPOCAAgent)
+    agent.gamma = 0.9
+    agent.lmbda = 1.0
+    agent.enable_popart = False
+    agent.device = torch.device('cpu')
+
+    rewards = torch.tensor([[[1.0]]])
+    values = torch.tensor([[[0.5]]])
+    dones = torch.tensor([[[0.0]]])
+    truncs = torch.tensor([[[0.0]]])
+    bootstrap_value = torch.tensor([0.7])
+
+    returns = agent.compute_bootstrapped_returns(rewards, values, dones, truncs, bootstrap_value)
+    expected = rewards.squeeze() + agent.gamma * bootstrap_value
+    assert torch.allclose(returns.squeeze(), expected)


### PR DESCRIPTION
## Summary
- include final state's bootstrap in `_compute_gae_with_padding`
- add a regression test for `compute_bootstrapped_returns`