### PR TITLE
Fix bootstrap return shape for multiple agents

### DIFF
--- a/Content/Python/Source/Runner.py
+++ b/Content/Python/Source/Runner.py
@@ -224,8 +224,12 @@ class RLRunner:
         tr_t = torch.stack(truncs, dim=0).unsqueeze(0)
 
         with torch.no_grad():
+            if self.num_agents_cfg == 1:
+                b_value = bootstrap_value.unsqueeze(0)
+            else:
+                b_value = bootstrap_value.view(1, self.num_agents_cfg)
             returns = self.agent.compute_bootstrapped_returns(
-                r_t, v_t, d_t, tr_t, bootstrap_value.view(1, 1)
+                r_t, v_t, d_t, tr_t, b_value
             )
         returns_ep = returns.squeeze(0)
 

--- a/Content/Python/Source/tests/test_returns.py
+++ b/Content/Python/Source/tests/test_returns.py
@@ -24,3 +24,23 @@ def test_bootstrapped_returns_uses_bootstrap_value():
     returns = agent.compute_bootstrapped_returns(rewards, values, dones, truncs, bootstrap_value)
     expected = rewards.squeeze() + agent.gamma * bootstrap_value
     assert torch.allclose(returns.squeeze(), expected)
+
+
+def test_bootstrapped_returns_multi_agent_vector():
+    agent = MAPOCAAgent.__new__(MAPOCAAgent)
+    agent.gamma = 0.9
+    agent.lmbda = 1.0
+    agent.enable_popart = False
+    agent.device = torch.device('cpu')
+
+    rewards = torch.tensor([[[1.0, 2.0]]])
+    values = torch.tensor([[[0.5, 0.5]]])
+    dones = torch.tensor([[[0.0]]])
+    truncs = torch.tensor([[[0.0]]])
+    bootstrap_value = torch.tensor([0.7, 1.0])
+
+    returns = agent.compute_bootstrapped_returns(
+        rewards, values, dones, truncs, bootstrap_value.view(1, -1)
+    )
+    expected = rewards.squeeze() + agent.gamma * bootstrap_value
+    assert torch.allclose(returns.squeeze(), expected)


### PR DESCRIPTION
## Summary
- keep bootstrap value per-agent in `_finalize_rollout`
- test multi-agent bootstrapped return calculation