### PR TITLE
Fix GAE truncation logic

### DIFF
--- a/Content/Python/Source/tests/test_returns.py
+++ b/Content/Python/Source/tests/test_returns.py
@@ -62,3 +62,20 @@ def test_bootstrapped_returns_truncated_no_done():
     returns = agent.compute_bootstrapped_returns(rewards, values, dones, truncs, bootstrap_value)
     expected_last = rewards[0, -1, 0] + agent.gamma * bootstrap_value
     assert torch.allclose(returns[0, -1, 0], expected_last)
+
+
+def test_compute_returns_resets_on_truncation():
+    agent = MAPOCAAgent.__new__(MAPOCAAgent)
+    agent.gamma = 0.9
+    agent.lmbda = 1.0
+    agent.enable_popart = False
+    agent.device = torch.device("cpu")
+
+    rewards = torch.tensor([[[1.0], [2.0]]])
+    values = torch.tensor([[[0.5], [0.6]]])
+    dones = torch.tensor([[[0.0], [0.0]]])
+    truncs = torch.tensor([[[0.0], [1.0]]])
+
+    returns = agent.compute_returns(rewards, values, dones, truncs)
+    expected = torch.tensor([[[1.0], [2.0]]])
+    assert torch.allclose(returns, expected)


### PR DESCRIPTION
## Summary
- incorporate `tr` arg into `_compute_gae_with_padding`
- reset returns when episodes are truncated
- ignore truncation mask in `compute_bootstrapped_returns`
- test that `compute_returns` handles truncation

## Testing
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686d2b283fec832390fb750b25aca320