### PR TITLE
Add CNNSpatialEmbedder wiring

### DIFF
--- a/Content/Python/Configs/TerraShift.json
+++ b/Content/Python/Configs/TerraShift.json
@@ -230,6 +230,7 @@
                 "cnn_stem_kernels": [8, 4, 3],
                 "cnn_stem_strides": [4, 2, 1],
                 "cnn_stem_group_norms": [8, 8, 8],
+                "target_pool_scale": 8,
                 "add_spatial_coords_to_cnn_input": true
               },
               {

--- a/Content/Python/Configs/TerraShift_Large.json
+++ b/Content/Python/Configs/TerraShift_Large.json
@@ -400,6 +400,7 @@
                                     16,
                                     16
                                 ],
+                                "target_pool_scale": 8,
                                 "add_spatial_coords_to_cnn_input": true
                             },
                             {


### PR DESCRIPTION
## Summary
- implement CNNSpatialEmbedder creation in CrossAttentionFeatureExtractor
- update configs with `target_pool_scale` for height map inputs
- document CrossAttentionFeatureExtractor behavior