### PR TITLE
Fix TerraShift respawn and reward flags

### DIFF
--- a/Source/Mecanum_Robot_RL/Private/TerraShift/StateManager.cpp
+++ b/Source/Mecanum_Robot_RL/Private/TerraShift/StateManager.cpp
@@ -192,11 +192,7 @@ void UStateManager::Reset(int32 NumObjects, int32 CurrentAgents)
         CurrPos[i] = FVector::ZeroVector;
 
         RespawnTimer[i] = 0.f;
-        RespawnDelays[i] = 0.0f;
-        if (BaseRespawnDelay > 0.0f)
-        {
-            RespawnDelays[i] = BaseRespawnDelay * static_cast<float>(i);
-        }
+        RespawnDelays[i] = BaseRespawnDelay;
     }
 
     // 3) Reset NxN height arrays & step counter
@@ -415,7 +411,6 @@ void UStateManager::RespawnGridObjects()
 
             ObjectSlotStates[i] = EObjectSlotState::Active;
             bShouldResp[i] = false;
-            bShouldCollect[i] = false;
             RespawnTimer[i] = 0.f;
 
             PrevVel[i] = FVector::ZeroVector;


### PR DESCRIPTION
## Summary
- ensure respawn delay uses the configured value for each object
- keep reward collection flag until the reward is issued