### PR TITLE
Fix state checks and size validation

### DIFF
--- a/Content/Python/Source/Environment.py
+++ b/Content/Python/Source/Environment.py
@@ -226,10 +226,14 @@ class SharedMemoryInterface(EnvCommunicationInterface):
             calculated_total_state_size_this_call = self.parsed_central_obs_size + expected_agent_size_this_call
 
             if SingleEnvStateSize_from_ue != calculated_total_state_size_this_call:
-                print(f"CRITICAL WARNING in get_states: SingleEnvStateSize from UE ({SingleEnvStateSize_from_ue}) "
-                    f"does not match Python's calculated size ({calculated_total_state_size_this_call}). "
-                    f"Python Central: {self.parsed_central_obs_size}, Python Agent: {expected_agent_size_this_call}. "
-                    "Check JSON consistency between UE (StateManager params) and Python (environment.shape.state).")
+                raise ValueError(
+                    "Shared memory state size mismatch: UE reports {} but Python expects {} (central {}, agent {}).".format(
+                        SingleEnvStateSize_from_ue,
+                        calculated_total_state_size_this_call,
+                        self.parsed_central_obs_size,
+                        expected_agent_size_this_call,
+                    )
+                )
             
             actual_total_state_data_size = NumEnvironments * SingleEnvStateSize_from_ue
             

--- a/Content/Python/Source/Runner.py
+++ b/Content/Python/Source/Runner.py
@@ -278,14 +278,19 @@ class RLRunner:
 
     def _handle_get_actions(self):
         states_from_comm, dones_from_comm, truncs_from_comm, needs_action = self.agentComm.get_states()
-        
-        if (
-            not states_from_comm
-            or "central" not in states_from_comm
-            or not states_from_comm.get("central")
-            or "agent" not in states_from_comm
-            or states_from_comm.get("agent") is None
-        ):
+
+        has_central_state = (
+            states_from_comm
+            and "central" in states_from_comm
+            and states_from_comm.get("central")
+        )
+        has_agent_state = (
+            states_from_comm
+            and "agent" in states_from_comm
+            and states_from_comm.get("agent") is not None
+        )
+
+        if not (has_central_state or has_agent_state):
             # This can happen if initial shared memory read is empty or parsing fails in agentComm
             print("RLRunner: Received empty or invalid states_from_comm in _handle_get_actions. Skipping.")
             # Still need to signal UE to avoid deadlock if it's waiting for actions
@@ -300,11 +305,6 @@ class RLRunner:
             return
 
         current_states_dict: Dict[str, Any] = {}
-        has_central_state = "central" in states_from_comm and states_from_comm["central"]
-        has_agent_state = "agent" in states_from_comm and states_from_comm["agent"] is not None
-
-        if not has_central_state and not has_agent_state:
-            raise ValueError("RLRunner: states_from_comm must contain at least 'central' or 'agent' key with data.")
 
         if has_central_state:
             current_states_dict["central"] = {

--- a/Source/Mecanum_Robot_RL/Private/SharedMemoryAgentCommunicator.cpp
+++ b/Source/Mecanum_Robot_RL/Private/SharedMemoryAgentCommunicator.cpp
@@ -433,6 +433,7 @@ int32 USharedMemoryAgentCommunicator::ComputeSingleEnvStateSize(int32 NumAgentsT
                     {
                         int32 h = 0;
                         int32 w = 0;
+                        int32 c = ShapeConfig->GetOrDefaultInt(TEXT("c"), 1); // channel count defaults to 1
 
                         // *** KEY FIX STARTS HERE ***
                         // For the height map, use the specific resolution from the StateManager config to ensure consistency.
@@ -456,7 +457,7 @@ int32 USharedMemoryAgentCommunicator::ComputeSingleEnvStateSize(int32 NumAgentsT
                             w = ShapeConfig->GetOrDefaultInt(TEXT("w"), 0);
                         }
                         // *** KEY FIX ENDS HERE ***
-                        TotalSize += (h * w);
+                        TotalSize += (h * w * c);
                     }
                     else if (CompType.Equals(TEXT("sequence"), ESearchCase::IgnoreCase))
                     {


### PR DESCRIPTION
## Summary
- relax RLRunner state presence check to allow central **or** agent observations
- fail fast when shared memory state sizes mismatch
- account for channel count when computing 2D matrix observation size