### PR TITLE
Add adaptive tokenization and parallel attention

### DIFF
--- a/Content/Python/Configs/TerraShift.json
+++ b/Content/Python/Configs/TerraShift.json
@@ -221,6 +221,7 @@
             "id_num_freqs": 8,
             "conv_init_scale": 1.0,
             "linear_init_scale": 1.0,
+            "fusion_type": "parallel",
             "central_processing_configs": [
               {
                 "name": "height_map",
@@ -235,7 +236,13 @@
                 "swin_stages": [
                   {"window_size": 4, "merge": true}
                 ],
-                "final_patch_tokens": 16
+                "final_patch_tokens": 16,
+                "adaptive_tokenizer": {
+                  "base_tokens": 16,
+                  "min_tokens": 8,
+                  "max_tokens": 24,
+                  "importance_hidden": 64
+                }
               },
               {
                 "name": "gridobject_sequence",

--- a/Content/Python/Configs/TerraShift.json
+++ b/Content/Python/Configs/TerraShift.json
@@ -236,7 +236,6 @@
                 "swin_stages": [
                   {"window_size": 4, "merge": true}
                 ],
-                "final_patch_tokens": 16,
                 "adaptive_tokenizer": {
                   "base_tokens": 16,
                   "min_tokens": 8,

--- a/Content/Python/Configs/TerraShift_Large.json
+++ b/Content/Python/Configs/TerraShift_Large.json
@@ -221,6 +221,7 @@
             "id_num_freqs": 8,
             "conv_init_scale": 1.0,
             "linear_init_scale": 1.0,
+            "fusion_type": "parallel",
             "central_processing_configs": [
               {
                 "name": "height_map",
@@ -235,7 +236,13 @@
                 "swin_stages": [
                   {"window_size": 4, "merge": true}
                 ],
-                "final_patch_tokens": 16
+                "final_patch_tokens": 16,
+                "adaptive_tokenizer": {
+                  "base_tokens": 16,
+                  "min_tokens": 8,
+                  "max_tokens": 24,
+                  "importance_hidden": 64
+                }
               },
               {
                 "name": "gridobject_sequence",

--- a/Content/Python/Configs/TerraShift_Large.json
+++ b/Content/Python/Configs/TerraShift_Large.json
@@ -236,7 +236,6 @@
                 "swin_stages": [
                   {"window_size": 4, "merge": true}
                 ],
-                "final_patch_tokens": 16,
                 "adaptive_tokenizer": {
                   "base_tokens": 16,
                   "min_tokens": 8,


### PR DESCRIPTION
## Summary
- add `AdaptiveSpatialTokenizer` to select top tokens from spatial features
- add `ParallelCrossAttention` and `HierarchicalCrossAttention`
- update `ResidualAttention` to optionally return attention without residual
- integrate new modules into `CNNSpatialEmbedder` and `CrossAttentionFeatureExtractor`
- parameterize tokenizer via config, add `fusion_type` configuration